### PR TITLE
Ensure culture-independent number format when (de)serializing.

### DIFF
--- a/Packages/com.dman.l-system/Runtime/NumberFormatHelper.cs
+++ b/Packages/com.dman.l-system/Runtime/NumberFormatHelper.cs
@@ -1,0 +1,32 @@
+﻿using System.Globalization;
+using System.Threading;
+using UnityEngine;
+
+namespace Dman.LSystem
+{
+#if UNITY_EDITOR
+    [UnityEditor.InitializeOnLoad]
+#endif
+    public static class NumberFormatHelper
+    {
+        static NumberFormatHelper()
+        {
+            InitializeInvariantNumberFormat();
+        }
+
+        /// <summary>
+        /// Sets the NumberFormat of the CurrentThreads CurrentCulture to Invariant, for when deserializing l-systems.
+        /// </summary>
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
+        public static void InitializeInvariantNumberFormat()
+        {
+            var currentThreadsCultureInfoClone = (CultureInfo)Thread.CurrentThread.CurrentCulture.Clone();
+            currentThreadsCultureInfoClone.NumberFormat = NumberFormatInfo.InvariantInfo;
+            System.Threading.Thread.CurrentThread.CurrentCulture = currentThreadsCultureInfoClone;
+
+            #if DEBUG
+            Debug.Log($"NumberFormatHelper: CurrentCultures NumberFormat set to Invariant.");
+            #endif
+        }
+    }
+}

--- a/Packages/com.dman.l-system/Runtime/NumberFormatHelper.cs.meta
+++ b/Packages/com.dman.l-system/Runtime/NumberFormatHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dfa023aefc347864c8b1629cb294ea84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I got a lot of issues like these
`SyntaxException: Assets/PlantBuilder/LSystems/tree/resourceTree.lsystem: r(a, water, maxWater, glucose, maxGlucose, flow, maxFlow, counterFlow, maxCounterFlow) < S(x) : water >= maxWater                         -> a(0.01, 0.01, 0.01)S(x) : Token "0.01" is neither a numeric value, a variable, nor a syntatical token`

When loading the project, this little class fixes that.